### PR TITLE
Print debug

### DIFF
--- a/0x00-ls/helpers1.c
+++ b/0x00-ls/helpers1.c
@@ -117,7 +117,7 @@ char *_strcopy(char *string)
 void printFileList(file_list_t *head, bool cmdLineArgs)
 {
 	file_list_t *temp = head;
-	bool firstInList = true;
+	bool filesPrinted = false;
 
 	/* if reverse flag is on, advance to tail for reversed traversal */
 	if (reverseOrder)
@@ -128,7 +128,7 @@ void printFileList(file_list_t *head, bool cmdLineArgs)
 	{
 		if (cmdLineArgs || displayAllowed(temp->f_name))
 		{
-			if (!firstInList)
+			if (filesPrinted)
 			{
 				if (singleColumn || longFormat)
 					printf("\n");
@@ -141,7 +141,7 @@ void printFileList(file_list_t *head, bool cmdLineArgs)
 			else
 				printf("%s", temp->f_name);
 
-			firstInList = false;
+			filesPrinted = true;
 		}
 
 		/* next node */
@@ -150,8 +150,8 @@ void printFileList(file_list_t *head, bool cmdLineArgs)
 		else
 			temp = temp->next;
 
-		/* final newline */
-		if (!temp)
+		/* final newline only if files were allowed display */
+		if (!temp && filesPrinted)
 			printf("\n");
 	}
 }

--- a/0x00-ls/helpers2.c
+++ b/0x00-ls/helpers2.c
@@ -15,6 +15,7 @@ file_list_t *addListNode(file_list_t **head, char *filename, char *path,
 	file_list_t *new;
 	char *rl_buf = NULL;
 	size_t rl_bufSize = 256;
+	ssize_t read_bytes = 0;
 
 	rl_buf = malloc(rl_bufSize);
 	new = malloc(sizeof(file_list_t));
@@ -28,8 +29,15 @@ file_list_t *addListNode(file_list_t **head, char *filename, char *path,
 	new->f_name = _strcopy(filename);
 	if (S_ISLNK(st.st_mode))
 	{
-		readlink(filename, rl_buf, rl_bufSize);
-		new->f_slnk = _strcopy(rl_buf);
+		read_bytes = readlink(path, rl_buf, rl_bufSize - 1);
+		if (read_bytes == -1)
+			fileError(path);
+		else
+		{
+			/* readlink does not automatically NULL-terminate */
+			rl_buf[read_bytes] = '\0';
+			new->f_slnk = _strcopy(rl_buf);
+		}
 	}
 	else
 		new->f_slnk = NULL;

--- a/0x00-ls/helpers4.c
+++ b/0x00-ls/helpers4.c
@@ -68,7 +68,7 @@ void printDirs(file_list_t *dir_list_head, bool cmdLineArgs,
 	if (nonFlagArgs < 2 && !(temp->next))
 		onlyOneDir = true;
 
-	/* first dir in list omits leading newline */
+	/* first dir in arg-derived list omits leading newline */
 	if (!onlyOneDir && !(temp->prev))
 		firstDir = true;
 
@@ -82,7 +82,8 @@ void printDirs(file_list_t *dir_list_head, bool cmdLineArgs,
 		if (dirParseAllowed(temp->f_name, cmdLineArgs)
 		    && temp->dir_files)
 		{
-			if (!onlyOneDir && !firstDir)
+			if ((!onlyOneDir && !firstDir) ||
+			    !cmdLineArgs)
 				printf("\n");
 
 			/* recusive mode prints dir name even if only one arg */


### PR DESCRIPTION
fixed valgrind 'uninitialized value' error in _strcopy by manually NULL-terminating the readlink buffer, plus refinements to newline placement for recursion.